### PR TITLE
fix: missed syntax

### DIFF
--- a/el-clone.el
+++ b/el-clone.el
@@ -27,7 +27,7 @@
 
 ;;; Code:
 
-(provide 'cl-lib)
+(require 'cl-lib)
 
 (defcustom el-clone-root (locate-user-emacs-file "el-clone")
   "Set el-clone root directory."


### PR DESCRIPTION
使おうとしてコード見たら本来 require であろう場所でなぜか `(provide 'cl-lib)` していたので直しました